### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 2.1.0
+
+### Dependency Updates
+* `playx_navigation: ^2.0.0`
+
+### Navigation Enhancements (`playx_navigation` 2.0.0)
+* **Updated `PlayxNavigationSettings.goRouter`** to accept the new `PlayxPageConfig? config` parameter, enabling global defaults for:
+  * `loadingWidget` — widget shown while a binding's `onEnter` is executing.
+  * `waitForBinding` — whether routes block their build on `onEnter` completion.
+  * `shellBuilder` — persistent page chrome (AppBar, Drawer) rendered immediately during transitions.
+  * `initTransitionDuration` — crossfade animation duration between loading and content states.
+* **Updated `PlayxMaterialApp` and `PlayxPlatformApp`** to forward `PlayxPageConfig` to `PlayxNavigationBuilder`, enabling global page configuration when using GoRouter.
+* Route-level settings override global `PlayxPageConfig` defaults.
+
+#### Example:
+```dart
+PlayxMaterialApp(
+  navigationSettings: PlayxNavigationSettings.goRouter(
+    goRouter: myRouter,
+    config: PlayxPageConfig(
+      loadingWidget: Center(child: CircularProgressIndicator()),
+      waitForBinding: false,
+      shellBuilder: (context, state, isInitialized, child) => Scaffold(
+        appBar: AppBar(title: Text('My App')),
+        body: child,
+      ),
+    ),
+  ),
+);
+```
+
 ## 2.0.0
 
 ### SDK & Dependency Updates

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,7 +25,8 @@ void main() async {
 
 final goRouter = GoRouter(
   routes: [
-    PlayxRoute(path: '/', builder: (context, state) => const Home()),
+    PlayxRoute(
+        path: '/', builder: (context, state, isInitialized) => const Home()),
   ],
 );
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: b8fe52979ff12432ecf8f0abf6ff70410b1bb734be1c9e4f2f86807ad7166c79
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.1.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -433,10 +433,10 @@ packages:
     dependency: transitive
     description:
       name: go_router
-      sha256: "7974313e217a7771557add6ff2238acb63f635317c35fa590d348fb238f00896"
+      sha256: "5540e4a3f416dd4a93458257b908eb88353cbd0fb5b0a3d1bd7d849ba1e88735"
       url: "https://pub.dev"
     source: hosted
-    version: "17.1.0"
+    version: "17.2.1"
   http:
     dependency: transitive
     description:
@@ -537,18 +537,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -691,7 +691,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
   playx_core:
     dependency: transitive
     description:
@@ -712,10 +712,10 @@ packages:
     dependency: transitive
     description:
       name: playx_navigation
-      sha256: "7acc4491a2fce4007a29fa831e088c63f877d8db8ef470da1750b1a4473bdf8b"
+      sha256: "31f774a4da59e7264d2647094b35f0640b78f65cfd68fa3f82f19e28bbe22776"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.0"
   playx_network:
     dependency: transitive
     description:
@@ -776,26 +776,26 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "288aee3d35f252ac0dc3a4b0accbbe7212fa2867604027f2cc5bc65334afd743"
+      sha256: "9f9a35c2e74ed79e16373268e0c79bc00988412d4b30b63eb369d2fa32e6814e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.16.0"
+    version: "9.17.0"
   sentry_dio:
     dependency: transitive
     description:
       name: sentry_dio
-      sha256: "750afa9a14297908038b91b6322efb3f42d24aa79a21eb09053425e283d6c7ef"
+      sha256: "905a0f93256ce694a66b00f442ae227b1edc1973e5a326a5328050cb01a7ccae"
       url: "https://pub.dev"
     source: hosted
-    version: "9.16.0"
+    version: "9.17.0"
   sentry_flutter:
     dependency: transitive
     description:
       name: sentry_flutter
-      sha256: f9e87d5895cc437902aa2b081727ee7e46524fe7cc2e1910f535480a3eeb8bed
+      sha256: "2de3cc0652934dd9d833aef578e8723ccba73dd229016b60533701e5890395d6"
       url: "https://pub.dev"
     source: hosted
-    version: "9.16.0"
+    version: "9.17.0"
   shared_preferences:
     dependency: transitive
     description:
@@ -965,10 +965,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/models/playx_navigation_settings.dart
+++ b/lib/src/models/playx_navigation_settings.dart
@@ -62,6 +62,18 @@ class PlayxNavigationSettings {
   /// Indicates whether to use Router-based navigation or GoRouter.
   final bool useRouter;
 
+  /// Optional global configuration for all [PlayxPage] instances when
+  /// using [GoRouter]-based navigation.
+  ///
+  /// Sets defaults for [PlayxPageConfig.loadingWidget],
+  /// [PlayxPageConfig.waitForBinding], [PlayxPageConfig.shellBuilder],
+  /// and [PlayxPageConfig.initTransitionDuration] that individual routes
+  /// can override.
+  ///
+  /// Only applicable when using the [PlayxNavigationSettings.goRouter]
+  /// constructor.
+  final PlayxPageConfig? config;
+
   /// Creates navigation settings for traditional [Navigator] navigation.
   ///
   /// This constructor sets up various properties related to Navigator-based navigation.
@@ -81,7 +93,8 @@ class PlayxNavigationSettings {
        routeInformationParser = null,
        routerDelegate = null,
        goRouter = null,
-       backButtonDispatcher = null;
+       backButtonDispatcher = null,
+       config = null;
 
   /// Creates navigation settings that use the Router instead of Navigator.
   ///
@@ -102,7 +115,8 @@ class PlayxNavigationSettings {
        goRouter = null,
        home = null,
        includeSentryNavigationObserver = false,
-       navigatorObservers = null;
+       navigatorObservers = null,
+       config = null;
 
   /// Creates navigation settings that use the GoRouter instead of Navigator.
   ///
@@ -111,6 +125,7 @@ class PlayxNavigationSettings {
     required GoRouter this.goRouter,
     this.navigatorKey,
     this.builder,
+    this.config,
   }) : useRouter = true,
        routes = null,
        initialRoute = null,

--- a/lib/src/widgets/playx_material_app.dart
+++ b/lib/src/widgets/playx_material_app.dart
@@ -185,6 +185,7 @@ class PlayxMaterialApp extends StatelessWidget {
                     ? PlayxNavigationBuilder(
                         builder: (ctx) => materialApp,
                         router: navigationSettings.goRouter!,
+                        config: navigationSettings.config,
                       )
                     : materialApp;
               },

--- a/lib/src/widgets/playx_platform_app.dart
+++ b/lib/src/widgets/playx_platform_app.dart
@@ -192,6 +192,7 @@ class PlayxPlatformApp extends StatelessWidget {
                     ? PlayxNavigationBuilder(
                         builder: (ctx) => platformApp,
                         router: navigationSettings.goRouter!,
+                        config: navigationSettings.config,
                       )
                     : platformApp;
               },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playx
 description: Playx eco system helps with redundant features as it provides many utilities for themes, widgets and more.
-version: 2.0.0
+version: 2.1.0
 homepage: https://sourcya.io
 repository: https://github.com/playx-flutter/playx
 issue_tracker: https://github.com/playx-flutter/playx/issues
@@ -23,14 +23,14 @@ dependencies:
   playx_theme: ^2.0.0
   playx_widget: ^0.5.0
   playx_network: ^1.0.0
-  playx_navigation: ^1.0.0
+  playx_navigation: ^2.0.0
   playx_localization: ^0.4.0
   queen_validators: ^1.0.1
-  sentry_flutter: ^9.16.0
+  sentry_flutter: ^9.17.0
   flutter_animate: ^4.5.2
   internet_connection_checker_plus: ^2.9.1+2
-  connectivity_plus: ^7.1.0
-  get: ^4.7.3
+  connectivity_plus: ^7.1.1
+  get: 4.7.3
 
 
 dev_dependencies:


### PR DESCRIPTION
## 2.1.0

### Dependency Updates
* `playx_navigation: ^2.0.0`

### Navigation Enhancements (`playx_navigation` 2.0.0)
* **Updated `PlayxNavigationSettings.goRouter`** to accept the new `PlayxPageConfig? config` parameter, enabling global defaults for:
  * `loadingWidget` — widget shown while a binding's `onEnter` is executing.
  * `waitForBinding` — whether routes block their build on `onEnter` completion.
  * `shellBuilder` — persistent page chrome (AppBar, Drawer) rendered immediately during transitions.
  * `initTransitionDuration` — crossfade animation duration between loading and content states.
* **Updated `PlayxMaterialApp` and `PlayxPlatformApp`** to forward `PlayxPageConfig` to `PlayxNavigationBuilder`, enabling global page configuration when using GoRouter.
* Route-level settings override global `PlayxPageConfig` defaults.

#### Example:
```dart
PlayxMaterialApp(
  navigationSettings: PlayxNavigationSettings.goRouter(
    goRouter: myRouter,
    config: PlayxPageConfig(
      loadingWidget: Center(child: CircularProgressIndicator()),
      waitForBinding: false,
      shellBuilder: (context, state, isInitialized, child) => Scaffold(
        appBar: AppBar(title: Text('My App')),
        body: child,
      ),
    ),
  ),
);
```